### PR TITLE
Bookmarking support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggquickeda
 Title: Quickly Explore Your Data Using 'ggplot2' and 'table1' Summary Tables
-Version: 0.2.2.9999
+Version: 0.3.0.9999
 Authors@R: c(
     person("Samer", "Mouksassi", email = "samermouksassi@gmail.com",
       role = c("aut", "cre"),comment = c(ORCID = "https://orcid.org/0000-0002-7152-6654")),
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Michael", "Sachs", email = "sachsmc@gmail.com",
       role = c("aut"), comment = "provided ggkm code"),
     person("James", "Craig", email = "james.craig@certara.com",
-      role = c("ctb"), comment = "Create pkgdown website")
+      role = c("aut"), comment = "implemented bookmarking and created pkgdown website")
     )
 Description: Quickly and easily perform exploratory data analysis by uploading your
      data as a 'csv' file. Start generating insights using 'ggplot2' plots and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ License: MIT + file LICENSE
 SystemRequirements: pandoc with https support
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/R/run_ggquickeda.R
+++ b/R/run_ggquickeda.R
@@ -3,21 +3,36 @@
 #' Run the \code{ggquickeda} application. 
 #' 
 #' @param data The initial data.frame to load into the application.
-#' @param settingsFile The path to the file that contains the application settings.
+#' @param ... Additional arguments
 #' 
 #' @examples
 #' if (interactive()) {
 #'   run_ggquickeda()
 #' }
 #' @export
-run_ggquickeda <- function(data = NULL, settingsFile = NULL) {
+run_ggquickeda <- function(data = NULL, ...) {
   if (!is.null(data) && !is.data.frame(data)) {
     stop("data must be a data.frame", call. = FALSE)
   }
+  
+  args <- list(...)
   appDir <- system.file("shinyapp", package = "ggquickeda")
+  
   if (appDir == "") {
     stop("Could not find shiny app directory. Try re-installing `ggquickeda`.",
          call. = FALSE)
+  } else if (!is.null(args$phx_app_dir)) {
+    #phx_appDir should be created prior to running ggquickeda?, #add validation check on files
+    stopifnot(dir.exists(args$phx_app_dir))
+    appDir <- file.path(args$phx_app_dir, "shinyapp")
+    
+    if (file.exists(file.path(appDir, "stop.txt"))) {
+      message("Removing previous stop file")
+      file.remove(file.path(appDir, "stop.txt"))
+    }
+    message("phx_app_dir: ", appDir)
+    .GlobalEnv$ggquickeda_phx_app_dir <- appDir
+    on.exit(rm(ggquickeda_phx_app_dir, envir = .GlobalEnv))
   }
   
   if (!is.null(data)) {
@@ -25,9 +40,14 @@ run_ggquickeda <- function(data = NULL, settingsFile = NULL) {
     on.exit(rm(ggquickeda_initdata, envir = .GlobalEnv))
   }
 
-  if (!is.null(settingsFile)) {
-    .GlobalEnv$ggquickeda_settingsfile <- settingsFile
+  if (!is.null(args$settingsFile)) {
+    .GlobalEnv$ggquickeda_settingsfile <- args$settingsFile
     on.exit(rm(ggquickeda_settingsfile, envir = .GlobalEnv))
+  }
+  if (!is.null(args$phx_bookmark_dir)) {
+    .GlobalEnv$phx_bookmark_dir <- args$phx_bookmark_dir
+    message("phx_bookmark_dir: ", phx_bookmark_dir)
+    on.exit(rm(phx_bookmark_dir, envir = .GlobalEnv))
   }
   
   shiny::runApp(appDir, display.mode = "normal")

--- a/R/run_ggquickeda.R
+++ b/R/run_ggquickeda.R
@@ -3,13 +3,14 @@
 #' Run the \code{ggquickeda} application. 
 #' 
 #' @param data The initial data.frame to load into the application.
+#' @param settingsFile The path to the file that contains the application settings.
 #' 
 #' @examples
 #' if (interactive()) {
 #'   run_ggquickeda()
 #' }
 #' @export
-run_ggquickeda <- function(data = NULL) {
+run_ggquickeda <- function(data = NULL, settingsFile = NULL) {
   if (!is.null(data) && !is.data.frame(data)) {
     stop("data must be a data.frame", call. = FALSE)
   }
@@ -23,8 +24,14 @@ run_ggquickeda <- function(data = NULL) {
     .GlobalEnv$ggquickeda_initdata <- data
     on.exit(rm(ggquickeda_initdata, envir = .GlobalEnv))
   }
+
+  if (!is.null(settingsFile)) {
+    .GlobalEnv$ggquickeda_settingsfile <- settingsFile
+    on.exit(rm(ggquickeda_settingsfile, envir = .GlobalEnv))
+  }
+  
   shiny::runApp(appDir, display.mode = "normal")
 }
 
 # Make CRAN happy
-if (getRversion() >= "2.15.1") utils::globalVariables(c("ggquickeda_initdata"))
+if (getRversion() >= "2.15.1") utils::globalVariables(c("ggquickeda_initdata", "ggquickeda_settingsfile"))

--- a/R/run_ggquickeda.R
+++ b/R/run_ggquickeda.R
@@ -22,7 +22,6 @@ run_ggquickeda <- function(data = NULL, ...) {
     stop("Could not find shiny app directory. Try re-installing `ggquickeda`.",
          call. = FALSE)
   } else if (!is.null(args$phx_app_dir)) {
-    #phx_appDir should be created prior to running ggquickeda?, #add validation check on files
     stopifnot(dir.exists(args$phx_app_dir))
     appDir <- file.path(args$phx_app_dir, "shinyapp")
     
@@ -40,10 +39,6 @@ run_ggquickeda <- function(data = NULL, ...) {
     on.exit(rm(ggquickeda_initdata, envir = .GlobalEnv))
   }
 
-  if (!is.null(args$settingsFile)) {
-    .GlobalEnv$ggquickeda_settingsfile <- args$settingsFile
-    on.exit(rm(ggquickeda_settingsfile, envir = .GlobalEnv))
-  }
   if (!is.null(args$phx_bookmark_dir)) {
     .GlobalEnv$phx_bookmark_dir <- args$phx_bookmark_dir
     message("phx_bookmark_dir: ", phx_bookmark_dir)
@@ -54,4 +49,4 @@ run_ggquickeda <- function(data = NULL, ...) {
 }
 
 # Make CRAN happy
-if (getRversion() >= "2.15.1") utils::globalVariables(c("ggquickeda_initdata", "ggquickeda_settingsfile"))
+if (getRversion() >= "2.15.1") utils::globalVariables(c("ggquickeda_initdata", "ggquickeda_phx_app_dir", "phx_bookmark_dir"))

--- a/R/run_ggquickeda.R
+++ b/R/run_ggquickeda.R
@@ -3,7 +3,7 @@
 #' Run the \code{ggquickeda} application. 
 #' 
 #' @param data The initial data.frame to load into the application.
-#' @param ... Additional arguments
+#' @param ... Additional arguments for bookmarking
 #' 
 #' @examples
 #' if (interactive()) {

--- a/inst/shinyapp/global.R
+++ b/inst/shinyapp/global.R
@@ -27,6 +27,8 @@ suppressMessages({
   library(RPostgres)
 })
 
+enableBookmarking(store = "server")
+
 DATABASE_CONN <- NULL
 PGDATABASE <- Sys.getenv("PGDATABASE")
 PGHOST <- Sys.getenv("PGHOST")

--- a/inst/shinyapp/global.R
+++ b/inst/shinyapp/global.R
@@ -205,6 +205,13 @@ manual_scale <- function(aesthetic, values = NULL, ...) {
   return(items)
 }
 
+.get_choice_items_num <- function(data) {
+  MODEDF <- sapply(data, function(x) is.numeric(x))
+  NAMESTOKEEP2<- names(data)[MODEDF]
+  items <- c("None",NAMESTOKEEP2, "yvalues") 
+  return(items)
+}
+
 .get_choice_facet_scales <- function(x = NULL, y = NULL) {
   items <- c("fixed","free_x","free_y","free")   
   if (is.null(x) && !is.null(y) && length(y) > 1 ){

--- a/inst/shinyapp/global.R
+++ b/inst/shinyapp/global.R
@@ -175,6 +175,33 @@ manual_scale <- function(aesthetic, values = NULL, ...) {
   else res <- as.factor(res)
   res
 }
+
+.get_choice_items <- function(data, x = NULL, y = NULL, pastevarin = NULL) {
+  items <- names(data)
+  names(items) <- items
+  items <- c("None",items)
+  if ( !is.null(x) ){
+    items <- c(items, "yvars","yvalues") 
+  }
+  if ( !is.null(y) ){
+    items <- c(items, "xvars","xvalues") 
+  }
+  if (!is.null(pastevarin) && length(pastevarin) > 1 ){
+    nameofcombinedvariables<- paste(as.character(pastevarin),collapse="_",sep="") 
+    items <- c(items,nameofcombinedvariables)
+  }
+  return(items)
+}
+
+.get_choice_items_char <- function(data) {
+  MODEDF <- sapply(data, function(x) is.numeric(x))
+  NAMESTOKEEP2<- names(data)  [ !MODEDF ]
+  items <- NAMESTOKEEP2
+  names(items) <- items
+  items <- c("None",items)
+  return(items)
+}
+
 .trim <- function(x){gsub("^\\s+|\\s+$", "", x)}
 # from survminer
 

--- a/inst/shinyapp/global.R
+++ b/inst/shinyapp/global.R
@@ -205,6 +205,22 @@ manual_scale <- function(aesthetic, values = NULL, ...) {
   return(items)
 }
 
+.get_choice_facet_scales <- function(x = NULL, y = NULL) {
+  items <- c("fixed","free_x","free_y","free")   
+  if (is.null(x) && !is.null(y) && length(y) > 1 ){
+    items <- c("free_y","fixed","free_x","free")    
+  }
+  if (is.null(y) && !is.null(x) && length(x) > 1 ){
+    items <- c("free_x","fixed","free_y","free")    
+  }
+  if (!is.null(x) && !is.null(y) && (length(y) > 1  || 
+      length(x) > 1)  ){
+    items <- c("free","fixed","free_x","free_y")    
+  }
+  return(items)
+}
+
+
 .trim <- function(x){gsub("^\\s+|\\s+$", "", x)}
 # from survminer
 

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -7796,4 +7796,9 @@ function(input, output, session) {
     values$maindata <- read.csv("data/sample_data.csv", na.strings = c("NA","."),
                                 stringsAsFactors = TRUE)
   }
+
+  
+  # ----- File Settings ------
+
+  source(file.path("server", "file-settings.R"), local = TRUE)$value
 }

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -1004,14 +1004,8 @@ function(input, output, session) {
   
   output$pastevar <- renderUI({
     items <- choice_items_char()
-    prev_input <- input$pastevarin
-    if (!is.null(prev_input)) {
-      selected <- prev_input
-    } else {
-      selected <- NULL
-    }
     selectizeInput("pastevarin", "Combine the categories of these two variables:",
-                   choices = items, multiple=TRUE, selected = selected,
+                   choices = items, multiple=TRUE,
                    options = list(
                      maxItems = 2 ,
                      placeholder = 'Please select two variables',

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -75,12 +75,20 @@ function(input, output, session) {
   
   # If this app was launched from a function that explicitly set an initial dataset
   if (exists("ggquickeda_initdata")) {
-    values$maindata <- get("ggquickeda_initdata")
-    mockFileUpload("Initial Data")
+    message("init data found")
+    if (exists("phx_bookmark_dir") &&
+               file.exists(file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir), "input.rds"))) {
+      message("using bookmarked startup")
+      useBookMark <- TRUE
+    } else {
+      useBookMark <- FALSE
+      values$maindata <- get("ggquickeda_initdata")
+      mockFileUpload("Initial Data")
+    }
   }
   
   # Kill the application/R session when a single shiny session is closed
-  session$onSessionEnded(stopApp)
+  #session$onSessionEnded(stopApp)
   
   # Variables to help with maintaining the dynamic number of "change the labels
   # of a variable" boxes

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -627,27 +627,34 @@ function(input, output, session) {
   }
   })#zzz 
 
-  observe({ if(input$histogramaddition=="None"){
-  updateRadioButtons(session, "densityaddition",
-                     choices = c("Density" = "Density",
-                       "Counts" = "Counts",
-                       "Scaled Density" = "Scaled Density",
-                       "None" = "None"))
-    
-  }
-  })
-  observe({ if(input$histogramaddition!="None" && input$histogrambinwidth== "userbinwidth"){
-    updateRadioButtons(session, "densityaddition",
-                       choices = c("Density" = "Density",
-                                   "Counts" = "Counts",
-                                   "Match Histo Count"="histocount",
-                                   "Scaled Density" = "Scaled Density",
-                                   "None" = "None"))
-    
-  }
-  })
+  observeEvent(c(input$histogrambinwidth), {
+    items <- c(
+      "Density" = "Density",
+      "Counts" = "Counts",
+      "Scaled Density" = "Scaled Density",
+      "None" = "None"
+    )
+    if (input$histogramaddition != "None" &&
+        input$histogrambinwidth == "userbinwidth") {
+        items <- c(
+          "Match Histo Count" = "histocount",
+          items
+        )
+    }
+    if (!is.null(input$densityaddition) && input$densityaddition %in% items) {
+      selected <- input$densityaddition
+    } else {
+      selected <- NULL
+    }
+    updateRadioButtons(
+      session,
+      "densityaddition",
+      choices = items,
+      selected = selected
+    )
+  }, ignoreInit = TRUE)
   
-  observe({
+  observeEvent(finalplotdata(), {
     if( (is.null(input$y) && !is.numeric(finalplotdata()[,"xvalues"] )) ||
         (is.null(input$x) && !is.numeric(finalplotdata()[,"yvalues"] ))
          ) {
@@ -658,19 +665,16 @@ function(input, output, session) {
       shinyjs::enable(id="barplotaddition")
       updateCheckboxInput(session, "barplotaddition", value = TRUE)
     }
-  })
-  observe({
     if( (is.null(input$y) &&  is.numeric(finalplotdata()[,"xvalues"] )) ||
         (is.null(input$x) &&  is.numeric(finalplotdata()[,"yvalues"] ))
     ) {
       shinyjs::enable(id="histogramaddition")
       shinyjs::enable(id="densityaddition")
-      updateRadioButtons(session, "densityaddition" , selected = "Density")
+      #updateRadioButtons(session, "densityaddition" , selected = "Density")
       updateCheckboxInput(session, "barplotaddition", value = FALSE)
       shinyjs::disable(id="barplotaddition")
-      
     }
-  })
+  }, ignoreInit = TRUE)
   
   observeEvent(input$KM, {
     if (input$KM=="None") {

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -10,6 +10,7 @@ function(input, output, session) {
   # create reactive values for choices of renderUI inputs
   choice_items <- reactiveVal()
   choice_items_char <- reactiveVal()
+  choice_items_num <- reactiveVal()
   choice_facet_scales <- reactiveVal()
   choice_items_dstatscolextrain <- reactiveVal()
   # special case for bookmarking quick_relabel_n input
@@ -94,6 +95,7 @@ function(input, output, session) {
       values$maindata <- get("ggquickeda_initdata")
       choice_items(.get_choice_items(get("ggquickeda_initdata")))
       choice_items_char(.get_choice_items_char(get("ggquickeda_initdata")))
+      choice_items_num(.get_choice_items_num(get("ggquickeda_initdata")))
       choice_items_dstatscolextrain(.get_choice_items(get("ggquickeda_initdata")))
       choice_facet_scales(.get_choice_facet_scales())
       mockFileUpload("Initial Data")
@@ -103,6 +105,7 @@ function(input, output, session) {
   observeEvent(c(input$x, input$y, input$pastevarin), {
     choice_items(.get_choice_items(values$maindata, input$x, input$y, input$pastevarin))
     choice_items_char(.get_choice_items_char(values$maindata))
+    choice_items_num(.get_choice_items_num(values$maindata))
     choice_facet_scales(.get_choice_facet_scales(input$x, input$y))
     choice_items_dstatscolextrain(.get_choice_items(values$maindata, 
                                                     x = NULL, #avoid xvalues
@@ -359,6 +362,7 @@ function(input, output, session) {
                                 sep = input$fileseparator)
     choice_items(.get_choice_items(values$maindata))
     choice_items_char(.get_choice_items_char(values$maindata))
+    choice_items_num(.get_choice_items_num(values$maindata))
     choice_items_dstatscolextrain(.get_choice_items(values$maindata))
     choice_facet_scales(.get_choice_facet_scales())
     # if(input$ninetyninemissing){
@@ -382,6 +386,7 @@ function(input, output, session) {
     values$maindata[,"time_DT"] <- as.POSIXct(values$maindata[,"Time"],origin ="01-01-1970",format="%H")
     choice_items(.get_choice_items(values$maindata))
     choice_items_char(.get_choice_items_char(values$maindata))
+    choice_items_num(.get_choice_items_num(values$maindata))
     choice_items_dstatscolextrain(.get_choice_items(values$maindata))
     choice_facet_scales(.get_choice_facet_scales())
     mockFileUpload("Sample Data")
@@ -758,9 +763,14 @@ function(input, output, session) {
     if (!is.null(input$catvarin) && length(input$catvarin ) >=1) {
         NAMESTOKEEP2 <- NAMESTOKEEP2 [ !is.element(NAMESTOKEEP2,input$catvarin) ]
     }
+    if (!is.null(input$catvarquantin) && input$catvarquantin %in% NAMESTOKEEP2) {
+      selected <- input$catvarquantin
+    } else {
+      selected <- NULL
+    }
     selectInput('catvarquantin',
                 label = 'Recode into Quantile Categories:',
-                choices = NAMESTOKEEP2, multiple=TRUE)
+                choices = NAMESTOKEEP2, multiple=TRUE, selected = selected)
   })
   
   # Show/hide the "N of cut quantiles" input
@@ -788,7 +798,12 @@ function(input, output, session) {
     if (!is.null(input$catvarin) && (length(input$catvarin ) >=1 )) {
         NAMESTOKEEP2<-NAMESTOKEEP2 [ !is.element(NAMESTOKEEP2,input$catvarin) ]
     }
-    selectInput('catvar2in',label = 'Treat as Categories:',choices=NAMESTOKEEP2,multiple=TRUE)
+    if (!is.null(input$catvar2in) && input$catvar2in %in% NAMESTOKEEP2) {
+      selected <- input$catvar2in
+    } else {
+      selected <- NULL
+    }
+    selectInput('catvar2in',label = 'Treat as Categories:',choices=NAMESTOKEEP2,multiple=TRUE, selected = selected)
   })
   
   output$catvar3 <- renderUI({
@@ -805,13 +820,22 @@ function(input, output, session) {
     if (!is.null(input$catvar2in) && length(input$catvar2in ) >=1) {
       NAMESTOKEEP2 <- NAMESTOKEEP2 [ !is.element(NAMESTOKEEP2,input$catvar2in) ]
     }
-    selectizeInput(  "catvar3in", 'Custom cuts of this variable, defaults to min, median, max before any applied filtering:',
-                     choices =NAMESTOKEEP2 ,multiple=FALSE,
-                     options = list(    placeholder = 'Please select a variable',
-                                        onInitialize = I('function() { this.setValue(""); }')
-                     )
+    # names(NAMESTOKEEP2) <- NAMESTOKEEP2
+    NAMESTOKEEP2 <- c("", NAMESTOKEEP2)
+    if (!is.null(input$catvar3in) && input$catvar3in %in% NAMESTOKEEP2) {
+      selected <- input$catvar3in
+    } else {
+      selected <- NULL
+    }
+    selectInput(
+      "catvar3in",
+      'Custom cuts of this variable, defaults to min, median, max before any applied filtering:',
+      choices = NAMESTOKEEP2 ,
+      multiple = FALSE,
+      selected = selected
     )
   })
+  
   output$ncuts2 <- renderUI({
     df <-values$maindata
     validate(need(!is.null(df), "Please select a data set"))
@@ -1055,7 +1079,7 @@ function(input, output, session) {
     validate(need(!is.null(df), "Please select a data set"))
     NUNIQUEDF <- sapply(df, function(x) length(unique(x)))
     NAMESTOKEEP<- names(df)  [ NUNIQUEDF  < input$inmaxlevels ]
-    selectInput("infiltervar1" , "Filter variable (1):",c('None',NAMESTOKEEP ) )
+    selectInput("infiltervar1" , "Filter variable (1):",c('None',NAMESTOKEEP ))
   })
   
   output$filtervar2 <- renderUI({
@@ -1063,7 +1087,7 @@ function(input, output, session) {
     validate(need(!is.null(df), "Please select a data set"))
     NUNIQUEDF <- sapply(df, function(x) length(unique(x)))
     NAMESTOKEEP<- names(df)  [ NUNIQUEDF  < input$inmaxlevels ]
-    selectInput("infiltervar2" , "Filter variable (2):",c('None',NAMESTOKEEP ) )
+    selectInput("infiltervar2" , "Filter variable (2):",c('None',NAMESTOKEEP ))
   })
   
   output$filtervar3 <- renderUI({
@@ -1071,7 +1095,7 @@ function(input, output, session) {
     validate(need(!is.null(df), "Please select a data set"))
     NUNIQUEDF <- sapply(df, function(x) length(unique(x)))
     NAMESTOKEEP<- names(df)  [ NUNIQUEDF  < input$inmaxlevels ]
-    selectInput("infiltervar3" , "Filter variable (3):",c('None',NAMESTOKEEP ) )
+    selectInput("infiltervar3" , "Filter variable (3):",c('None',NAMESTOKEEP ))
   })
   
   
@@ -1875,14 +1899,16 @@ function(input, output, session) {
   # Add UI and corresponding outputs+observers for a "merge factor levels"
   # section
   add_factor_merge_box <- function() {
+    req(recodedata3())
     factor_merge_vals$num_current <- factor_merge_vals$num_current + 1
     
     df <- recodedata3()
+    
     factors <- df %>%
       sapply(is.factor) %>%
       which() %>%
       names()
-    
+ 
     insertUI(
       selector = "#factor_merge_placeholder", where = "beforeEnd",
       immediate = TRUE,
@@ -1919,7 +1945,6 @@ function(input, output, session) {
     # when the user selects a factor to merge
     observeEvent(input[[paste0("factor_merge_select_", num1)]], {
       selected_var <- input[[paste0("factor_merge_select_", num1)]]
-      
       if (selected_var == "") {
         shinyjs::hide(paste0("factor_merge_levels_", num1))
         return()
@@ -1928,7 +1953,7 @@ function(input, output, session) {
       
       df <- factor_merge_data()
       levelsvalues <- levels(df[[selected_var]])
-      
+
       updateCheckboxGroupInput(
         session, paste0("factor_merge_levels_", num1),
         choices = levelsvalues,
@@ -2193,7 +2218,12 @@ function(input, output, session) {
     if (length(input$x) > 1  ){
       items= c("xvars",None=".",items[items!="xvars"])
     }
-    selectInput("facetcolextrain", "Extra Column Split:",items)
+    if(!is.null(input$facetcolextrain) && input$facetcolextrain %in% items) {
+      selected <- input$facetcolextrain
+    } else {
+      selected <- NULL
+    }
+    selectInput("facetcolextrain", "Extra Column Split:",items, selected = selected)
   })
   
   output$facet_row_extra <- renderUI({
@@ -2206,7 +2236,12 @@ function(input, output, session) {
     if (length(input$y) > 1  ){
       items= c("yvars",None=".",items[items!="yvars"])
     }
-    selectInput("facetrowextrain", "Extra Row Split:",items)
+    if(!is.null(input$facetrowextrain) && input$facetrowextrain %in% items) {
+      selected <- input$facetrowextrain
+    } else {
+      selected <- NULL
+    }
+    selectInput("facetrowextrain", "Extra Row Split:",items, selected = selected)
   })
 
   output$facetscales <- renderUI({ 
@@ -2274,10 +2309,14 @@ function(input, output, session) {
   output$weight <- renderUI({
     df <- finalplotdata()
     validate(need(!is.null(df), "Please select a data set"))
-    MODEDF <- sapply(df, function(x) is.numeric(x))
-    NAMESTOKEEP2<- names(df)  [ MODEDF ]
-    items= c("None",NAMESTOKEEP2, "yvalues") 
-    selectInput("weightin", "Weight By:",items )
+    items <- choice_items_num()
+    prev_input <- input$weightin
+    if(!is.null(prev_input) && prev_input %in% items) {
+      selected <- prev_input
+    } else {
+      selected <- NULL
+    }
+    selectInput("weightin", "Weight By:",items, selected = selected )
   })
   outputOptions(output, "pointsize", suspendWhenHidden=FALSE)
   outputOptions(output, "fill", suspendWhenHidden=FALSE)

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -355,7 +355,10 @@ function(input, output, session) {
     
     values$maindata <- read.csv(file, na.strings = na.strings, stringsAsFactors = input$stringasfactor,
                                 sep = input$fileseparator)
-    choice_items(names(values$maindata))
+    items <- .get_choice_items(values$maindata)
+    choice_items(items)
+    items_char <- .get_choice_items_char(values$maindata)
+    choice_items_char(items_char)
     # if(input$ninetyninemissing){
     #   tempdata <-  values$maindata
     #   NUMCOLUMNS <- sapply(tempdata , function(x) is.numeric(x))
@@ -374,8 +377,11 @@ function(input, output, session) {
     values$maindata <- read.csv(file, na.strings = c("NA","."),
                                 stringsAsFactors = TRUE,
                                 sep = ",")
-    choice_items(names(values$maindata))
     values$maindata[,"time_DT"] <- as.POSIXct(values$maindata[,"Time"],origin ="01-01-1970",format="%H")
+    items <- .get_choice_items(values$maindata)
+    choice_items(items)
+    items_char <- .get_choice_items_char(values$maindata)
+    choice_items_char(items_char)
     mockFileUpload("Sample Data")
   })
   

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -1,85 +1,70 @@
 # File settings
 
-fileSettings <- reactiveValues(
-  canUse = FALSE,
-  canSave = FALSE,
-  filePath = "settings.rds",
-  fieldNames = c(
-    "x", "y",
-    "catvarin", "catvarquantin", "catvar2in", "contvarin", "catvar3in",
-    "colorin", "facetcolin", "pointshapein", "pointsizein",
-    "pointsizes", "pointstransparency")
-)
-
-# Load settings
-
-loadFileSettings <- function() {
-  if (!file.exists(fileSettings$filePath)) {
-    return()
-  }
-
-  # print("loadFileSettings()")
-  
-  oldCanSave <- fileSettings$canSave
-  fileSettings$canSave <- FALSE
-  
-  tryCatch({
-      savedInputs <- readRDS(fileSettings$filePath)
-      inputIds <- names(savedInputs) 
-      inputValues <- unlist(savedInputs)
-      # print(paste0("Loading field IDs: ", inputIds))
-      
-      for (i in 1:length(savedInputs)) {
-        session$sendInputMessage(inputIds[i], list(value=inputValues[[i]]))
-      }
-    },
-    finally = function() {
-      fileSettings$canSave <- oldCanSave      
-    }
-  )
-}
-
-observeEvent({
-  req(fileSettings$canUse, !is.null(values$maindata))
-}, {
-  # print("observeEvent()")
-  loadFileSettings()
-  fileSettings$canSave <- TRUE
-}, once=TRUE)
-
-# Save settings
-
-saveFileSettings <- function() {
-  if (!fileSettings$canSave) {
-    return();
-  }
-  
-  # print("saveFileSettings()")
-
-  inputValues <- reactiveValuesToList(input)
-  inputNamesToExport <- fileSettings$fieldNames
-  inputValues <- inputValues[inputNamesToExport]
-  inputValues <- inputValues[order(match(inputValues, inputNamesToExport))]
-  inputValues <- inputValues[sapply(inputValues, function(x) !is.null(x))]
-  # print(inputValues)
-  saveRDS(inputValues, file = fileSettings$filePath)
-}
-
-# session$onFlush(function() {
-#   isolate(saveFileSettings());
-# }, once=FALSE)
-
-saveFileSettingsEventTrigger <- reactive({
-  list(fileSettings$canSave, reactiveValuesToList(input)[fileSettings$fieldNames])
-})
-
-observeEvent(saveFileSettingsEventTrigger(), {
-  saveFileSettings()
-});
-
+# fileSettings <- reactiveValues(
+#   canUse = FALSE,
+#   canSave = FALSE,
+#   bookmarkDir = "",
+#   fieldNames = c(
+#     "x", "y",
+#     "catvarin", "catvarquantin", "catvar2in", "contvarin", "catvar3in",
+#     "colorin", "facetcolin", "pointshapein", "pointsizein",
+#     "pointsizes", "pointstransparency")
+# )
 # Init
 
-if (exists("ggquickeda_settingsfile")) {
-  fileSettings$filePath <- get("ggquickeda_settingsfile")
-  fileSettings$canUse <- TRUE
-}
+latestBookmarkURL <- reactiveVal()
+
+onBookmarked(
+  fun = function(url) {
+    latestBookmarkURL(parseQueryString(url)) #Update reactiveVal for each session$doBookmarked
+  }
+)
+
+onRestore(function(state) {
+  values$maindata <- get("ggquickeda_initdata")
+})
+
+onRestored(function(state) {
+  mockFileUpload("Initial Data")
+  colorin <- state$input$colorin
+  print(paste0("updating input$colorin to ", colorin))
+  updateSelectInput(session, "colorin", selected = colorin)
+  #session$sendInputMessage(inputIds[i], list(value=inputValues[[i]]))
+
+  showNotification(paste("Restored session:", basename(state$dir)),
+                   duration = 10,
+                   type = "message")
+})
+
+# TO DO: Make below smarter with reactive listener for select input names
+observeEvent(c(input$x, input$y, input$colorin), {
+  session$doBookmark()
+  message(paste0("Bookmark copied from:", file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds")))
+  file.copy(from = file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds"),
+            to = file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir) , "input.rds"),
+            overwrite = TRUE)
+  message(paste0("Bookmark copied to:",file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir) , "input.rds")))
+  
+}, ignoreInit = TRUE)
+
+# Startup observer gets autodestroyed because no reactive domain, ui.r first loads, then we destory
+observe({
+  if(useBookMark && !file.exists("stop.txt")) {
+    restoreURL <-
+      paste0(
+        session$clientData$url_protocol,
+        "//",
+        session$clientData$url_hostname,
+        ":",
+        session$clientData$url_port,
+        session$clientData$url_pathname,
+        "?_state_id_=",
+        basename(phx_bookmark_dir)
+      )
+      writeLines("", con = "stop.txt")
+      cat(paste0("Restoring to: ", restoreURL, sep = "\n"))
+      message("...restoring bookmarked startup")
+      runjs(sprintf("window.location = '%s';", restoreURL))
+  }
+}, priority = 99)
+

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -37,7 +37,8 @@ bookMarkTriggers <- reactive({
     input$Constraints,
     input$scalesizearea,
     input$scalesizearearange1,
-    input$scalesizearearange2
+    input$scalesizearearange2,
+    input$height
   )
 })
 # Bookmark on plotObject() and misc bookmark triggers change (e.g., inputs that do not affect plot display)

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -1,0 +1,85 @@
+# File settings
+
+fileSettings <- reactiveValues(
+  canUse = FALSE,
+  canSave = FALSE,
+  filePath = "settings.rds",
+  fieldNames = c(
+    "x", "y",
+    "catvarin", "catvarquantin", "catvar2in", "contvarin", "catvar3in",
+    "colorin", "facetcolin", "pointshapein", "pointsizein",
+    "pointsizes", "pointstransparency")
+)
+
+# Load settings
+
+loadFileSettings <- function() {
+  if (!file.exists(fileSettings$filePath)) {
+    return()
+  }
+
+  # print("loadFileSettings()")
+  
+  oldCanSave <- fileSettings$canSave
+  fileSettings$canSave <- FALSE
+  
+  tryCatch({
+      savedInputs <- readRDS(fileSettings$filePath)
+      inputIds <- names(savedInputs) 
+      inputValues <- unlist(savedInputs)
+      # print(paste0("Loading field IDs: ", inputIds))
+      
+      for (i in 1:length(savedInputs)) {
+        session$sendInputMessage(inputIds[i], list(value=inputValues[[i]]))
+      }
+    },
+    finally = function() {
+      fileSettings$canSave <- oldCanSave      
+    }
+  )
+}
+
+observeEvent({
+  req(fileSettings$canUse, !is.null(values$maindata))
+}, {
+  # print("observeEvent()")
+  loadFileSettings()
+  fileSettings$canSave <- TRUE
+}, once=TRUE)
+
+# Save settings
+
+saveFileSettings <- function() {
+  if (!fileSettings$canSave) {
+    return();
+  }
+  
+  # print("saveFileSettings()")
+
+  inputValues <- reactiveValuesToList(input)
+  inputNamesToExport <- fileSettings$fieldNames
+  inputValues <- inputValues[inputNamesToExport]
+  inputValues <- inputValues[order(match(inputValues, inputNamesToExport))]
+  inputValues <- inputValues[sapply(inputValues, function(x) !is.null(x))]
+  # print(inputValues)
+  saveRDS(inputValues, file = fileSettings$filePath)
+}
+
+# session$onFlush(function() {
+#   isolate(saveFileSettings());
+# }, once=FALSE)
+
+saveFileSettingsEventTrigger <- reactive({
+  list(fileSettings$canSave, reactiveValuesToList(input)[fileSettings$fieldNames])
+})
+
+observeEvent(saveFileSettingsEventTrigger(), {
+  saveFileSettings()
+});
+
+# Init
+
+if (exists("ggquickeda_settingsfile")) {
+  fileSettings$filePath <- get("ggquickeda_settingsfile")
+  fileSettings$canUse <- TRUE
+}

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -24,8 +24,7 @@ onRestored(function(state) {
   savedInputs <- list(
                       "yaxisformat" = state$input$yaxisformat,
                       "xaxisformat" = state$input$xaxisformat,
-                      "Smooth" = state$input$Smooth,
-                      "flipthelevelsin", state$input$flipthelevelsin
+                      "Smooth" = state$input$Smooth
                       )
   inputIds <- names(savedInputs)
   for (i in seq_along(savedInputs)) {

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -12,6 +12,7 @@ onRestore(function(state) {
   values$maindata <- get("ggquickeda_initdata")
   choice_items(.get_choice_items(values$maindata, state$input$x, state$input$y, state$input$pastevarin))
   choice_items_char(.get_choice_items_char(values$maindata))
+  choice_items_num(.get_choice_items_num(values$maindata))
   choice_facet_scales(.get_choice_facet_scales(state$input$x, state$input$y))
   choice_items_dstatscolextrain(.get_choice_items(values$maindata, pastevarin =  state$input$pastevarin))
 })

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -10,44 +10,28 @@ onBookmarked(
 
 onRestore(function(state) {
   values$maindata <- get("ggquickeda_initdata")
-  items <- names(values$maindata)
-  names(items) <- items
-  items <- c("None",items)
-  if ( !is.null(state$input$y) ){
-    items <- c(items, "yvars","yvalues") 
-  }
-  if ( !is.null(state$input$x) ){
-    items <- c(items, "xvars","xvalues") 
-  }
-  if (!is.null(state$input$pastevarin) && length(state$input$pastevarin) > 1 ){
-    nameofcombinedvariables<- paste(as.character(state$input$pastevarin),collapse="_",sep="") 
-    items <- c(items,nameofcombinedvariables)
-  }
-  message("Settings choices_items() to: ", items)
+  items <- .get_choice_items(values$maindata, state$input$x, state$input$y, state$input$pastevarin)
   choice_items(items)
-  # TO DO
-  # Create additional reactiveVal for other choices where we are evaluating input$ inside
+  items_char <- .get_choice_items_char(values$maindata)
+  choice_items_char(items_char)
 })
 
 onRestored(function(state) {
-  # savedInputs <- list(
-  #                     "catvarin" = state$input$catvarin,
-  #                     "pastevarin" =  state$input$pastevarin,
-  #                     "colorin" = state$input$colorin,
-  #                     "facetcolin" =  state$input$facetcolin,
-  #                     "facetcolextrain" = state$input$facetcolextrain,
-  #                     "pointshapein" = state$input$pointshapein)
-  # inputIds <- names(savedInputs)
-  # for (i in 1:length(savedInputs)) {
-  #   session$sendInputMessage(inputIds[i], list(value=savedInputs[[i]]))
-  # }
   showNotification(paste("Restored session:", basename(state$dir)),
                    duration = 10,
                    type = "message")
+  # savedInputs <- list(
+  #                     "pastevarin" = state$input$pastevarin
+  #                     )
+  # inputIds <- names(savedInputs)
+  # for (i in seq_along(savedInputs)) {
+  #   session$sendInputMessage(inputIds[i], list(value=savedInputs[[i]]))
+  #   message(inputIds[i], "=", savedInputs[[i]])
+  # }
 })
 
-# TO DO: Make below smarter with reactive listener for select input names
-observeEvent(bookMarkTriggers(), {
+# Bookmark on plotObject() change
+observeEvent(plotObject(), {
   if (exists("phx_bookmark_dir")) {
   session$doBookmark()
   message(paste0("Bookmark copied from:", file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds")))
@@ -56,10 +40,9 @@ observeEvent(bookMarkTriggers(), {
             overwrite = TRUE)
   message(paste0("Bookmark copied to:",file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir) , "input.rds")))
   }
-  
 }, ignoreInit = TRUE)
 
-# Startup observer gets autodestroyed because no reactive domain, ui.r first loads, then we destory
+# Startup observer gets auto-destroyed because no reactive domain
 observe({
   if (exists("ggquickeda_phx_app_dir")) {
     if (useBookMark && !file.exists("stop.txt")) {
@@ -81,24 +64,3 @@ observe({
     }
   }
 }, priority = 99)
-
-bookMarkTriggers <- reactive({
-  list(
-    input$catvarin,
-    input$catvar2in,
-    input$catvar3in,
-    input$catvarquantin,
-    input$colorin,
-    input$contvarin,
-    input$facetcolin,
-    input$facetcolextrain,
-    input$facetrowin,
-    input$pointshapein,
-    input$pointsizein,
-    input$pointsizes,
-    input$pointstransparency,
-    input$x,
-    input$y
-  )
-})
-

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -30,8 +30,15 @@ onRestored(function(state) {
   # }
 })
 
-# Bookmark on plotObject() change
-observeEvent(plotObject(), {
+# Create additional bookmark triggers that we want to persist, but don't affect plotObject() change
+bookMarkTriggers <- reactive({
+  list(
+    input$Penalty,
+    input$Constraints
+  )
+})
+# Bookmark on plotObject() and misc bookmark triggers change (e.g., inputs that do not affect plot display)
+observeEvent(c(plotObject(), bookMarkTriggers()), {
   if (exists("phx_bookmark_dir")) {
   session$doBookmark()
   message(paste0("Bookmark copied from:", file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds")))

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -10,10 +10,10 @@ onBookmarked(
 
 onRestore(function(state) {
   values$maindata <- get("ggquickeda_initdata")
-  items <- .get_choice_items(values$maindata, state$input$x, state$input$y, state$input$pastevarin)
-  choice_items(items)
-  items_char <- .get_choice_items_char(values$maindata)
-  choice_items_char(items_char)
+  choice_items(.get_choice_items(values$maindata, state$input$x, state$input$y, state$input$pastevarin))
+  choice_items_char(.get_choice_items_char(values$maindata))
+  choice_facet_scales(.get_choice_facet_scales(state$input$x, state$input$y))
+  
 })
 
 onRestored(function(state) {
@@ -34,7 +34,10 @@ onRestored(function(state) {
 bookMarkTriggers <- reactive({
   list(
     input$Penalty,
-    input$Constraints
+    input$Constraints,
+    input$scalesizearea,
+    input$scalesizearearange1,
+    input$scalesizearearange2
   )
 })
 # Bookmark on plotObject() and misc bookmark triggers change (e.g., inputs that do not affect plot display)

--- a/inst/shinyapp/server/file-settings.R
+++ b/inst/shinyapp/server/file-settings.R
@@ -1,16 +1,4 @@
-# File settings
-
-# fileSettings <- reactiveValues(
-#   canUse = FALSE,
-#   canSave = FALSE,
-#   bookmarkDir = "",
-#   fieldNames = c(
-#     "x", "y",
-#     "catvarin", "catvarquantin", "catvar2in", "contvarin", "catvar3in",
-#     "colorin", "facetcolin", "pointshapein", "pointsizein",
-#     "pointsizes", "pointstransparency")
-# )
-# Init
+# Bookmarking persistent state
 
 latestBookmarkURL <- reactiveVal()
 
@@ -22,49 +10,95 @@ onBookmarked(
 
 onRestore(function(state) {
   values$maindata <- get("ggquickeda_initdata")
+  items <- names(values$maindata)
+  names(items) <- items
+  items <- c("None",items)
+  if ( !is.null(state$input$y) ){
+    items <- c(items, "yvars","yvalues") 
+  }
+  if ( !is.null(state$input$x) ){
+    items <- c(items, "xvars","xvalues") 
+  }
+  if (!is.null(state$input$pastevarin) && length(state$input$pastevarin) > 1 ){
+    nameofcombinedvariables<- paste(as.character(state$input$pastevarin),collapse="_",sep="") 
+    items <- c(items,nameofcombinedvariables)
+  }
+  message("Settings choices_items() to: ", items)
+  choice_items(items)
+  # TO DO
+  # Create additional reactiveVal for other choices where we are evaluating input$ inside
 })
 
 onRestored(function(state) {
-  mockFileUpload("Initial Data")
-  colorin <- state$input$colorin
-  print(paste0("updating input$colorin to ", colorin))
-  updateSelectInput(session, "colorin", selected = colorin)
-  #session$sendInputMessage(inputIds[i], list(value=inputValues[[i]]))
-
+  # savedInputs <- list(
+  #                     "catvarin" = state$input$catvarin,
+  #                     "pastevarin" =  state$input$pastevarin,
+  #                     "colorin" = state$input$colorin,
+  #                     "facetcolin" =  state$input$facetcolin,
+  #                     "facetcolextrain" = state$input$facetcolextrain,
+  #                     "pointshapein" = state$input$pointshapein)
+  # inputIds <- names(savedInputs)
+  # for (i in 1:length(savedInputs)) {
+  #   session$sendInputMessage(inputIds[i], list(value=savedInputs[[i]]))
+  # }
   showNotification(paste("Restored session:", basename(state$dir)),
                    duration = 10,
                    type = "message")
 })
 
 # TO DO: Make below smarter with reactive listener for select input names
-observeEvent(c(input$x, input$y, input$colorin), {
+observeEvent(bookMarkTriggers(), {
+  if (exists("phx_bookmark_dir")) {
   session$doBookmark()
   message(paste0("Bookmark copied from:", file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds")))
   file.copy(from = file.path(".", "shiny_bookmarks", req(latestBookmarkURL()), "input.rds"),
             to = file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir) , "input.rds"),
             overwrite = TRUE)
   message(paste0("Bookmark copied to:",file.path(".", "shiny_bookmarks", basename(phx_bookmark_dir) , "input.rds")))
+  }
   
 }, ignoreInit = TRUE)
 
 # Startup observer gets autodestroyed because no reactive domain, ui.r first loads, then we destory
 observe({
-  if(useBookMark && !file.exists("stop.txt")) {
-    restoreURL <-
-      paste0(
-        session$clientData$url_protocol,
-        "//",
-        session$clientData$url_hostname,
-        ":",
-        session$clientData$url_port,
-        session$clientData$url_pathname,
-        "?_state_id_=",
-        basename(phx_bookmark_dir)
-      )
+  if (exists("ggquickeda_phx_app_dir")) {
+    if (useBookMark && !file.exists("stop.txt")) {
+      restoreURL <-
+        paste0(
+          session$clientData$url_protocol,
+          "//",
+          session$clientData$url_hostname,
+          ":",
+          session$clientData$url_port,
+          session$clientData$url_pathname,
+          "?_state_id_=",
+          basename(phx_bookmark_dir)
+        )
       writeLines("", con = "stop.txt")
       cat(paste0("Restoring to: ", restoreURL, sep = "\n"))
       message("...restoring bookmarked startup")
       runjs(sprintf("window.location = '%s';", restoreURL))
+    }
   }
 }, priority = 99)
+
+bookMarkTriggers <- reactive({
+  list(
+    input$catvarin,
+    input$catvar2in,
+    input$catvar3in,
+    input$catvarquantin,
+    input$colorin,
+    input$contvarin,
+    input$facetcolin,
+    input$facetcolextrain,
+    input$facetrowin,
+    input$pointshapein,
+    input$pointsizein,
+    input$pointsizes,
+    input$pointstransparency,
+    input$x,
+    input$y
+  )
+})
 

--- a/inst/shinyapp/ui.R
+++ b/inst/shinyapp/ui.R
@@ -3,9 +3,8 @@ function(request) {
   useShinyjs(),
   tags$link(rel = "stylesheet", href = "app.css"),
   tags$link(rel = "stylesheet", href = "table1-style.css"),
-  titlePanel(paste("Welcome to ggquickeda!",utils::packageVersion("ggquickeda"))),
   sidebarLayout(
-    sidebarPanel(
+    sidebarPanel(style = "padding-top: 0px;",
       tabsetPanel(id = "sidebar_upper_menus", selected="sidebar_inputs",
         tabPanel("Inputs", value = "sidebar_inputs", 
           tags$style(".shiny-file-input-progress {margin-bottom: 0px;margin-top: 0px}"),

--- a/inst/shinyapp/ui.R
+++ b/inst/shinyapp/ui.R
@@ -10,14 +10,16 @@ function(request) {
         tabPanel("Inputs", value = "sidebar_inputs", 
           tags$style(".shiny-file-input-progress {margin-bottom: 0px;margin-top: 0px}"),
           tags$style(".form-group {margin-bottom: 0px;margin-top: 0px}"),
-          tags$div(
-            tags$strong("Click Browse to choose csv file to upload with"),
-            inline_ui(radioButtons("fileseparator", NULL,
+          tags$div(class = ifelse(exists("ggquickeda_phx_app_dir"), "", "file-inputs"),
+            tags$div(
+              tags$strong("Click Browse to choose csv file to upload with"),
+              inline_ui(radioButtons("fileseparator", NULL,
                                    choices = c("comma (,)" = ",","or semicolon (;)" = ";"),
                                    selected = ",", inline = TRUE)),
-            "separators, or",actionLink("sample_data_btn", "use sample data")
-          ),
-          fileInput("datafile", NULL, multiple = FALSE, accept = c("csv")),
+              "separators, or",actionLink("sample_data_btn", "use sample data")
+            ),
+            fileInput("datafile", NULL, multiple = FALSE, accept = c("csv"))
+          ) %>% shinyjs::hidden(),
           checkboxInput("stringasfactor", "Character Variables as Factors?", TRUE),
           checkboxInput("ninetyninemissing", "Numeric Variables -99 as Missing?", FALSE),
           uiOutput("ycol"),

--- a/inst/shinyapp/ui.R
+++ b/inst/shinyapp/ui.R
@@ -2544,7 +2544,7 @@ function(request) {
                               icon = icon("sync")),
                  fluidRow(
                    column(3,
-                          div(id="quick_relabel_placeholder"),
+                          uiOutput("quick_relabel_placeholder"),
                           uiOutput("dstats_col_extra"),
                           uiOutput("flipthelevels")
                    ),

--- a/inst/shinyapp/ui.R
+++ b/inst/shinyapp/ui.R
@@ -1,4 +1,5 @@
-fluidPage(
+function(request) {
+  fluidPage(
   useShinyjs(),
   tags$link(rel = "stylesheet", href = "app.css"),
   tags$link(rel = "stylesheet", href = "table1-style.css"),
@@ -2596,3 +2597,5 @@ fluidPage(
       )#mainPanel
   )#sidebarLayout
 )#fluidPage
+}
+

--- a/man/geom_km.Rd
+++ b/man/geom_km.Rd
@@ -37,14 +37,10 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
-stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
-\code{"stat_count"})}
+layer, as a string.}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_kmband.Rd
+++ b/man/geom_kmband.Rd
@@ -37,14 +37,10 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
-stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
-\code{"stat_count"})}
+layer, as a string.}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_kmticks.Rd
+++ b/man/geom_kmticks.Rd
@@ -37,14 +37,10 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
-stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
-\code{"stat_count"})}
+layer, as a string.}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/run_ggquickeda.Rd
+++ b/man/run_ggquickeda.Rd
@@ -4,10 +4,12 @@
 \alias{run_ggquickeda}
 \title{Run the ggquickeda application}
 \usage{
-run_ggquickeda(data = NULL)
+run_ggquickeda(data = NULL, ...)
 }
 \arguments{
 \item{data}{The initial data.frame to load into the application.}
+
+\item{...}{Additional arguments for bookmarking}
 }
 \description{
 Run the \code{ggquickeda} application.

--- a/man/stat_km.Rd
+++ b/man/stat_km.Rd
@@ -40,14 +40,10 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use to display the data, either as a
-\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
-\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
+\item{geom}{The geometric object to use display the data}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/stat_kmband.Rd
+++ b/man/stat_kmband.Rd
@@ -44,14 +44,10 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use to display the data, either as a
-\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
-\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
+\item{geom}{The geometric object to use display the data}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/stat_kmticks.Rd
+++ b/man/stat_kmticks.Rd
@@ -36,14 +36,10 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{geom}{The geometric object to use to display the data, either as a
-\code{ggproto} \code{Geom} subclass or as a string naming the geom stripped of the
-\code{geom_} prefix (e.g. \code{"point"} rather than \code{"geom_point"})}
+\item{geom}{The geometric object to use display the data}
 
-\item{position}{Position adjustment, either as a string naming the adjustment
-(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
-position adjustment function. Use the latter if you need to change the
-settings of the adjustment.}
+\item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.


### PR DESCRIPTION
To support persistent state e.g., bookmarking in Phoenix 8.4, the following changes were made to `ggquickeda`, to be included in `0.3.0` CRAN release.

- Add server-side bookmarking capabilities in `file-settings.R`
- Misc refactor of `renderUI()` inputs to support bookmarking
- Additional helper functions supplied in `global.R`

Bookmarking has been tested by Certara SME and verified. QE testing to follow. All inputs are expected to persist with the exception of 'data-centric' inputs that use `insertUI` e.g., re-coding, merging of factor levels, filtering, etc.

The following script may be used for testing bookmarking:

```
# Testing ggquickeda persistent state, from RStudio
app_dir <- system.file("shinyapp", package = "ggquickeda")
temp_dir_name <- "appDirPhx"

phx_app_dir <- file.path(dirname(tempdir()), temp_dir_name)

if (!dir.exists(phx_app_dir)) {
  dir.create(phx_app_dir)
}

file.copy(app_dir, phx_app_dir, recursive=TRUE) #Copy app dir from R/library/ggquickeda to phx_app_dir

if (!dir.exists(file.path(phx_app_dir,"shinyapp", "shiny_bookmarks"))) {
  dir.create(file.path(phx_app_dir,"shinyapp", "shiny_bookmarks"))
}

phx_workflow_name <- "workflow1"
phx_bookmark_dir <- file.path(phx_app_dir,"shinyapp", "shiny_bookmarks", phx_workflow_name)

if (!dir.exists(phx_bookmark_dir)) {
  dir.create(phx_bookmark_dir)
}

# Phoenix to read in some data to R
data_path <- system.file(package="ggquickeda", "shinyapp", "data", "sample_data.csv")
data <- read.csv(data_path)

# Run ggquickeda
ggquickeda::run_ggquickeda(data, phx_app_dir = phx_app_dir, phx_bookmark_dir = phx_bookmark_dir)

# After closing initial shiny session, simply re-execute the entire script to restore session to previous bookmarked state
```