### PR TITLE
additional padding to top of fluid-page

### DIFF
--- a/inst/shinyapp/www/app.css
+++ b/inst/shinyapp/www/app.css
@@ -1,3 +1,7 @@
+.container-fluid {
+  padding-top:10px;
+}
+
 #save_plot_area {
   display: inline-block;
   margin-top: 15px;


### PR DESCRIPTION
Since the welcome message has been removed, additional padding at the top of the fluid page provides a better UI, otherwise, tabs are fixed to top of page.