### PR TITLE
Silence ggplot2 3.4.0 deprecation warnings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     GGally (>= 2.1.0),
     ggbeeswarm,
     ggh4x,
-    ggplot2 (>= 3.3.4),
+    ggplot2 (>= 3.4.0),
     ggpmisc,
     ggrepel (>= 0.7.0),
     ggpubr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,10 @@
 * fixing error in aspect.ratio not numeric (was also fixed in ggplot2)
 * fixing other regressions with ggpairs color and group
 * added support of pasting values of two/three variables where it was just a placeholder
-* added function `ggkmrisktable` to add facetable risk tables, km and by ntiles split exposures
-* added function `gglogisticexpdist` and `ggcontinuousexpdist` to add facetable logistic/linear regression with exposures split to  ntiles with exposure distributions by dose/group and optional y axis projections
+* added function `ggkmrisktable()` to add facetable risk tables, km and by ntiles split exposures
+* added function `gglogisticexpdist()` and `ggcontinuousexpdist()` to add facetable logistic/linear regression with exposures split to  ntiles with exposure distributions by dose/group and optional y axis projections
 * added link to github pages in description thanks to @olivroy
+* Fix part of ggplot2 3.4.0 deprecation warnings. (#27, @olivroy)
 
 # ggquickeda 0.3.0
 * added options to drop levels for user discrete shape and linetype scales

--- a/R/ggcontinuousexpdist.R
+++ b/R/ggcontinuousexpdist.R
@@ -406,10 +406,10 @@ ggcontinuousexpdist <- function(data = effICGI,
                         ggplot2::aes(linetype = "Linear Fit 95% CI"))+
     ggplot2::geom_line(data = predict_by_endpoint_expname_dose,
                        ggplot2::aes_string(y = "yhat", col = color_fill),
-                       alpha = 0.4, size = 2)+
+                       alpha = 0.4, linewidth = 2)+
     ggplot2::geom_line(data = predict_by_endpoint_expname_dose2,
                        ggplot2::aes_string(y = "yhat", col = color_fill),
-                       alpha = 0.4, size = 2.5)+
+                       alpha = 0.4, linewidth = 2.5)+
     ggplot2::geom_point(data = predict_by_endpoint_expname,
                         ggplot2::aes_string(x = "medexp", y = "ymid50", col = color_fill),
                         alpha = 0.4, size = 5)
@@ -418,13 +418,13 @@ ggcontinuousexpdist <- function(data = effICGI,
   if(exposure_distribution=="lineranges") {
     lineranges_ypos <- as.character(lineranges_ypos)
     p1l <- p1 +
-      ggplot2::geom_linerange(data = data.long.summaries.dose, size = 2, alpha = 0.4,
+      ggplot2::geom_linerange(data = data.long.summaries.dose, linewidth = 2, alpha = 0.4,
                               ggplot2::aes_string(xmin = "quant_10", xmax = "quant_90",y = lineranges_ypos,
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
       position = ggstance::position_dodgev(height = lineranges_dodge),inherit.aes = FALSE)+
-      ggplot2::geom_linerange(data = data.long.summaries.dose, size = 2.5, alpha = 0.4,
+      ggplot2::geom_linerange(data = data.long.summaries.dose, linewidth = 2.5, alpha = 0.4,
                               ggplot2::aes_string(xmin = "quant_25", xmax=  "quant_75", y = lineranges_ypos, 
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
@@ -503,13 +503,13 @@ ggcontinuousexpdist <- function(data = effICGI,
     yproj_xpos <- as.character(yproj_xpos)
     
     p2df <- p2d +
-      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, size = 2,
+      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, linewidth = 2,
                               ggplot2::aes_string(x = yproj_xpos, ymin = "ymid10", ymax = "ymid90",
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
                               position = ggplot2::position_dodge(width = yproj_dodge), inherit.aes = FALSE)+
-      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, size = 2.5,
+      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, linewidth = 2.5,
                               ggplot2::aes_string(x = yproj_xpos, ymin = "ymid25", ymax = "ymid75", col= color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),

--- a/R/ggkm.R
+++ b/R/ggkm.R
@@ -28,10 +28,14 @@ GeomKm <- ggplot2::ggproto("GeomKm", ggplot2::Geom,
                            },
                            
                            required_aes = c("x", "y"),
-                           default_aes = ggplot2::aes(colour="black", fill="grey60", size=.75,
+                           default_aes = ggplot2::aes(colour="black", fill="grey60", linewidth = .75,
                                                       linetype=1, weight=1, alpha = 1),
-                           draw_key = ggplot2::draw_key_path
-                           
+                           draw_key = ggplot2::draw_key_path,
+                           # To allow using size in ggplot2 < 3.4.0
+                           non_missing_aes = "size",
+
+                           # Tell ggplot2 to perform automatic renaming
+                           rename_size = TRUE                    
                            
 )
 
@@ -55,10 +59,16 @@ GeomKmband <- ggplot2::ggproto("GeomKmband", ggplot2::Geom,
                                },
                                
                                required_aes = c("x", "ymin", "ymax"),
-                               default_aes = ggplot2::aes(colour="black", fill="grey60", size=.75,
+                               default_aes = ggplot2::aes(colour="black", fill="grey60", linewidth=.75,
                                                           linetype=1, weight=1, alpha=0.4),
                                
-                               draw_key = ggplot2::draw_key_smooth
+                               draw_key = ggplot2::draw_key_smooth,
+                               
+                               # To allow using size in ggplot2 < 3.4.0 https://www.tidyverse.org/blog/2022/08/ggplot2-3-4-0-size-to-linewidth/
+                               non_missing_aes = "size",
+                               
+                               # Tell ggplot2 to perform automatic renaming
+                               rename_size = TRUE     
                                
 )
 
@@ -94,7 +104,6 @@ GeomKmticks <- ggplot2::ggproto("GeomKmticks", ggplot2::Geom,
                                   }
                                   
                                 },
-                                
                                 required_aes = c("x", "y"),
                                 non_missing_aes = c("size", "shape"),
                                 default_aes = ggplot2::aes(
@@ -154,7 +163,7 @@ geom_km <- function(mapping = NULL, data = NULL, stat = "km",
 #'   \item \code{alpha}
 #'   \item \code{color}
 #'   \item \code{linetype}
-#'   \item \code{size}
+#'   \item \code{linewidth}
 #' }
 #'
 #' @inheritParams ggplot2::geom_point
@@ -229,7 +238,7 @@ geom_kmticks <- function(mapping = NULL, data = NULL, stat = "kmticks",
 #' @export
 
 StatKm <- ggplot2::ggproto("StatKm", ggplot2::Stat,
-                           
+                           dropped_aes = c("status"),
                            compute_group = function(data, scales, trans = scales::identity_trans(), firstx = 0, firsty = 1,
                                                     type = "kaplan-meier", start.time = 0) {
                              
@@ -269,7 +278,7 @@ StatKm <- ggplot2::ggproto("StatKm", ggplot2::Stat,
 #' @export
 
 StatKmband <- ggplot2::ggproto("StatKmband", ggplot2::Stat,
-                               
+                               dropped_aes = "status",
                                compute_group = function(data, scales, trans = scales::identity_trans(), firstx = 0, firsty = 1,
                                                         type = "kaplan-meier", error = "greenwood", conf.type = "log",
                                                         conf.lower = "usual", start.time = 0, conf.int = 0.95) {
@@ -397,7 +406,7 @@ stat_km <- function(mapping = NULL, data = NULL, geom = "km",
 #'   \item \code{alpha}
 #'   \item \code{color}
 #'   \item \code{linetype}
-#'   \item \code{size}
+#'   \item \code{linewidth}
 #' }
 #'
 #' @inheritParams ggplot2::stat_identity
@@ -507,7 +516,7 @@ StatKmticks <- ggplot2::ggproto("StatKmticks", ggplot2::Stat,
                                   sf.df
                                   
                                 },
-                                
+                                dropped_aes = "status",
                                 default_aes = ggplot2::aes(y = ..survival.., x = ..time..),
                                 required_aes = c("time", "status")
                                 

--- a/R/gglogisticexpdist.R
+++ b/R/gglogisticexpdist.R
@@ -602,7 +602,7 @@ gglogisticexpdist <- function(data = effICGI,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
                               position = ggplot2::position_dodge(width = yproj_dodge), inherit.aes = FALSE)+
-      ggplot2::geom_point(data=predict_by_endpoint_expname, alpha = 0.4, linewidth = 3,
+      ggplot2::geom_point(data=predict_by_endpoint_expname, alpha = 0.4, size = 3,
                           ggplot2::aes_string(x = yproj_xpos, y = "ymid50", color = color_fill,
                                               group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),

--- a/R/gglogisticexpdist.R
+++ b/R/gglogisticexpdist.R
@@ -494,10 +494,10 @@ gglogisticexpdist <- function(data = effICGI,
                         ggplot2::aes(linetype = "Logistic Fit 95% CI"))+
     ggplot2::geom_line(data = predict_by_endpoint_expname_dose,
                        ggplot2::aes_string(y = "yhat", col = color_fill),
-                       alpha = 0.4, size = 2)+
+                       alpha = 0.4, linewidth = 2)+
     ggplot2::geom_line(data = predict_by_endpoint_expname_dose2,
                        ggplot2::aes_string(y = "yhat", col = color_fill),
-                       alpha = 0.4, size = 2.5)+
+                       alpha = 0.4, linewidth = 2.5)+
     ggplot2::geom_point(data = predict_by_endpoint_expname,
                         ggplot2::aes_string(x = "medexp", y = "ymid50", col = color_fill),
                         alpha = 0.4, size = 5)
@@ -507,13 +507,13 @@ gglogisticexpdist <- function(data = effICGI,
   if(exposure_distribution=="lineranges") {
     lineranges_ypos <- as.character(lineranges_ypos)
     p1l <- p1 +
-      ggplot2::geom_linerange(data = data.long.summaries.dose, size = 2, alpha = 0.4,
+      ggplot2::geom_linerange(data = data.long.summaries.dose, linewidth = 2, alpha = 0.4,
                               ggplot2::aes_string(xmin = "quant_10", xmax = "quant_90",y = lineranges_ypos,
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
       position = ggstance::position_dodgev(height = lineranges_dodge),inherit.aes = FALSE)+
-      ggplot2::geom_linerange(data = data.long.summaries.dose, size = 2.5, alpha = 0.4,
+      ggplot2::geom_linerange(data = data.long.summaries.dose, linewidth = 2.5, alpha = 0.4,
                               ggplot2::aes_string(xmin = "quant_25", xmax=  "quant_75", y = lineranges_ypos, 
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
@@ -591,19 +591,19 @@ gglogisticexpdist <- function(data = effICGI,
     yproj_xpos <- as.character(yproj_xpos)
     
     p2df <- p2d +
-      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, size = 2,
+      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, linewidth = 2,
                               ggplot2::aes_string(x = yproj_xpos, ymin = "ymid10", ymax = "ymid90",
                                                   col = color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
                               position = ggplot2::position_dodge(width = yproj_dodge), inherit.aes = FALSE)+
-      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, size = 2.5,
+      ggplot2::geom_linerange(data = predict_by_endpoint_expname, alpha = 0.4, linewidth = 2.5,
                               ggplot2::aes_string(x = yproj_xpos, ymin = "ymid25", ymax = "ymid75", col= color_fill,
                                                   group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
                               position = ggplot2::position_dodge(width = yproj_dodge), inherit.aes = FALSE)+
-      ggplot2::geom_point(data=predict_by_endpoint_expname, alpha = 0.4, size = 3,
-                          ggplot2::aes_string(x = yproj_xpos, y = "ymid50", col = color_fill,
+      ggplot2::geom_point(data=predict_by_endpoint_expname, alpha = 0.4, linewidth = 3,
+                          ggplot2::aes_string(x = yproj_xpos, y = "ymid50", color = color_fill,
                                               group=   paste0("interaction(",paste(as.character(c(DOSEinputvar,color_fill)) ,collapse=",",sep=""),")")
                               ),
                               position = ggplot2::position_dodge(width = yproj_dodge), inherit.aes = FALSE)

--- a/inst/shinyapp/server.R
+++ b/inst/shinyapp/server.R
@@ -2931,7 +2931,7 @@ function(input, output, session) {
            p <- p + geom_density(aes_string(y=densitytype),
                                  alpha=input$densityalpha,
                                  adjust=input$densityadjust,
-                                 size = input$densitylinesize)
+                                 linewidth = input$densitylinesize)
        }
         if(input$densityignorelinetype && !input$densityaddition%in% c("None","histocount")) {
           p <- p + geom_density(aes_string(binwidth=input$histobinwidth,
@@ -2939,21 +2939,21 @@ function(input, output, session) {
                                 alpha=input$densityalpha,
                                 adjust=input$densityadjust,
                                 linetype = input$densitylinetypes,
-                                size = input$densitylinesize)
+                                linewidth = input$densitylinesize)
         }
 
         if(!input$densityignorelinetype && input$densityaddition == "histocount" ) {
           p <- p + geom_density(aes(binwidth=input$histobinwidth, y=binwidth*..count..),
                                 alpha=input$densityalpha,
                                 adjust=input$densityadjust,
-                                size = input$densitylinesize)
+                                linewidth = input$densitylinesize)
         }
         if(input$densityignorelinetype && input$densityaddition=="histocount") {
           p <- p + geom_density(aes(binwidth=input$histobinwidth, y=binwidth*..count..),
                                 alpha=input$densityalpha,
                                 adjust=input$densityadjust,
                                 linetype = input$densitylinetypes,
-                                size = input$densitylinesize)
+                                linewidth = input$densitylinesize)
         }
 
 
@@ -5921,7 +5921,7 @@ function(input, output, session) {
               geom_line(
                 stat = "km",
                 trans = input$KMtrans ,
-                size = input$kmlinesize,
+                linewidth = input$kmlinesize,
                 alpha = input$kmlinealpha
               )
             
@@ -6698,23 +6698,23 @@ function(input, output, session) {
       
       if (input$customvline1)
         p <-    p +
-        geom_vline(xintercept=input$vline1,color=input$vlinecol1,linetype=input$vlinetype1,size=input$vlinesize1)
+        geom_vline(xintercept=input$vline1,color=input$vlinecol1,linetype=input$vlinetype1,linewidth=input$vlinesize1)
       if (input$customvline2)
         p <-    p +
-        geom_vline(xintercept=input$vline2,color=input$vlinecol2,linetype=input$vlinetype2,size=input$vlinesize2)      
+        geom_vline(xintercept=input$vline2,color=input$vlinecol2,linetype=input$vlinetype2,linewidth=input$vlinesize2)      
       
       if (input$customhline1)
         p <-    p +
-        geom_hline(yintercept=input$hline1,color=input$hlinecol1,linetype=input$hlinetype1,size=input$hlinesize1)
+        geom_hline(yintercept=input$hline1,color=input$hlinecol1,linetype=input$hlinetype1,linewidth=input$hlinesize1)
       
       if (input$customhline2)
         p <-    p +
-        geom_hline(yintercept=input$hline2,color=input$hlinecol2,linetype=input$hlinetype2,size=input$hlinesize2)     
+        geom_hline(yintercept=input$hline2,color=input$hlinecol2,linetype=input$hlinetype2,linewidth=input$hlinesize2)     
       
       if (input$identityline)
         p <-    p + geom_abline(intercept = 0, slope = 1,
                                 col = input$identitylinecol,
-                                size = input$identitylinesize,
+                                linewidth = input$identitylinesize,
                                 linetype = input$identitylinetype)  
 
       

--- a/man/geom_kmband.Rd
+++ b/man/geom_kmband.Rd
@@ -79,7 +79,7 @@ are in bold):
   \item \code{alpha}
   \item \code{color}
   \item \code{linetype}
-  \item \code{size}
+  \item \code{linewidth}
 }
 }
 

--- a/man/stat_kmband.Rd
+++ b/man/stat_kmband.Rd
@@ -129,7 +129,7 @@ are in bold):
   \item \code{alpha}
   \item \code{color}
   \item \code{linetype}
-  \item \code{size}
+  \item \code{linewidth}
 }
 }
 


### PR DESCRIPTION
Addresses #27 

I followed advice here:

https://www.tidyverse.org/blog/2022/08/ggplot2-3-4-0-size-to-linewidth/#the-fix

There are still some warnings about `aes_string()`, but that would require more work, as I think it would require updating to the latest standards of NS evaluation everywhere, in dplyr and ggplot2 code for consistency. Links for this: https://ggplot2.tidyverse.org/dev/articles/ggplot2-in-packages.html and https://dplyr.tidyverse.org/articles/programming.html

Warnings in https://smouksassi.github.io/ggquickeda/reference/geom_km.html will be silenced.